### PR TITLE
feat(factory): add `set_token_bytecode` method to lazily set token wasm

### DIFF
--- a/src/factory/Cargo.toml
+++ b/src/factory/Cargo.toml
@@ -5,12 +5,19 @@ version = "0.1.0"
 
 [dependencies]
 candid = "0.7"
-common = {path = "../common"}
+common = { path = "../common" }
 ic-cdk = "0.3"
 ic-cdk-macros = "0.3"
-ic-helpers = {git = "https://github.com/infinity-swap/ic-helpers.git", package = "ic-helpers", branch = "main"}
+
+ic-helpers = { git = "https://github.com/infinity-swap/ic-helpers.git", package = "ic-helpers", branch = "main" }
+ic-storage = { git = "https://github.com/infinity-swap/ic-helpers.git", package = "ic-storage" }
+ic-canister = { git = "https://github.com/infinity-swap/ic-helpers.git", package = "ic-canister" }
+
 serde = "1.0"
-ic-storage = {git = "https://github.com/infinity-swap/ic-helpers.git", package = "ic-storage"}
-ic-types = {git = "https://github.com/flyq/ic"}
-ledger-canister = {git = "https://github.com/flyq/ic"}
+ic-types = { git = "https://github.com/flyq/ic" }
+ledger-canister = { git = "https://github.com/flyq/ic" }
 thiserror = "1.0"
+
+[dev-dependencies]
+ic-agent = "0.13.0"
+tokio = { version = "1", features = ["macros"] }

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -15,7 +15,7 @@ ic_helpers::init_factory_api!(State, crate::state::get_token_bytecode());
 
 #[init]
 #[candid_method(init)]
-fn init(controller: Principal, ledger_principal: Option<Principal>) {
+pub fn init(controller: Principal, ledger_principal: Option<Principal>) {
     State::new(controller, ledger_principal).set_global_to_self();
 }
 
@@ -38,15 +38,19 @@ async fn get_token(name: String) -> Option<Principal> {
     State::get().borrow().factory.get(&name)
 }
 
+pub async fn set_token_bytecode_impl(bytecode: Vec<u8>) {
+    State::get().borrow_mut().token_wasm.replace(bytecode);
+}
+
 #[update(name = "set_token_bytecode")]
 #[candid_method(update, rename = "set_token_bytecode")]
-async fn set_token_bytecode(bytecode: Vec<u8>) {
+pub async fn set_token_bytecode(bytecode: Vec<u8>) {
     if State::get().borrow().controller() != ic_cdk::api::caller() {
         ic_cdk::api::call::reject("not authorized");
         return;
     }
 
-    State::get().borrow_mut().token_wasm.replace(bytecode);
+    set_token_bytecode_impl(bytecode).await;
 }
 
 /// Creates a new token.

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -16,7 +16,7 @@ ic_helpers::init_factory_api!(State, crate::state::get_token_bytecode());
 #[init]
 #[candid_method(init)]
 fn init(controller: Principal, ledger_principal: Option<Principal>) {
-    State::new(controller, ledger_principal).reset();
+    State::new(controller, ledger_principal).set_global_to_self();
 }
 
 /// Returns the token, or None if it does not exist.

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -21,6 +21,10 @@ fn init(controller: Principal, ledger_principal: Option<Principal>) {
 
 #[inspect_message]
 fn inspect_message_function() {
+    if ic_cdk::api::caller() == State::get().borrow().controller() {
+        return ic_cdk::api::call::accept_message();
+    }
+
     match &State::get().borrow().token_wasm {
         Some(_) => ic_cdk::api::call::accept_message(),
         None => ic_cdk::api::call::reject("the factory hasn't been completely intialized yet"),

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -105,7 +105,7 @@ pub async fn create_token(
         state
             .borrow()
             .factory
-            .create_with_cycles(get_token_bytecode(), (info,), cycles);
+            .create_with_cycles(&get_token_bytecode(), (info,), cycles);
 
     let canister = create_token
         .await

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -26,6 +26,19 @@ async fn get_token(name: String) -> Option<Principal> {
     State::get().borrow().factory.get(&name)
 }
 
+#[update(name = "set_token_bytecode")]
+#[candid_method(update, rename = "set_token_bytecode")]
+async fn set_token_bytecode(bytecode: Vec<u8>) {
+    if State::get().borrow().token_wasm.is_some() {
+        ic_cdk::api::call::reject("token bytecode is already set");
+        return;
+    }
+
+    let state = State::get();
+
+    state.borrow_mut().token_wasm.replace(bytecode);
+}
+
 /// Creates a new token.
 ///
 /// Creating a token canister with the factory requires one of the following:

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -16,12 +16,12 @@ ic_helpers::init_factory_api!(State, crate::state::get_token_bytecode());
 #[init]
 #[candid_method(init)]
 pub fn init(controller: Principal, ledger_principal: Option<Principal>) {
-    State::new(controller, ledger_principal).set_global_to_self();
+    State::new(controller, ledger_principal).reset();
 }
 
 #[inspect_message]
 fn inspect_message_function() {
-    if ic_cdk::api::caller() == State::get().borrow().controller() {
+    if ic_cdk::api::call::method_name() == "set_token_bytecode" {
         return ic_cdk::api::call::accept_message();
     }
 
@@ -122,4 +122,18 @@ pub async fn create_token(
     state.borrow_mut().factory.register(key, canister);
 
     Ok(principal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_set_token_bytecode_impl() {
+        assert_eq!(State::get().borrow().token_wasm, None);
+
+        set_token_bytecode_impl(vec![12, 3]).await;
+
+        assert_eq!(State::get().borrow().token_wasm, Some(vec![12, 3]));
+    }
 }

--- a/src/factory/src/lib.rs
+++ b/src/factory/src/lib.rs
@@ -1,5 +1,12 @@
-mod api;
+pub mod api;
 mod error;
 mod state;
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use candid::Principal;
+use ic_canister::{query, update, Canister};
+
 pub use self::api::*;
+pub use state::State;

--- a/src/factory/src/lib.rs
+++ b/src/factory/src/lib.rs
@@ -2,11 +2,5 @@ pub mod api;
 mod error;
 mod state;
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
-use candid::Principal;
-use ic_canister::{query, update, Canister};
-
 pub use self::api::*;
 pub use state::State;

--- a/src/factory/src/state.rs
+++ b/src/factory/src/state.rs
@@ -64,10 +64,10 @@ impl State {
     pub fn stable_restore() {
         let (mut loaded,): (Self,) = ::ic_cdk::storage::stable_restore().unwrap();
         let _ = loaded.token_wasm.take();
-        loaded.reset();
+        loaded.set_global_to_self();
     }
 
-    pub fn reset(self) {
+    pub fn set_global_to_self(self) {
         let state = State::get();
         let mut state = state.borrow_mut();
         *state = self;

--- a/src/factory/src/state.rs
+++ b/src/factory/src/state.rs
@@ -52,8 +52,8 @@ impl Default for State {
     }
 }
 
-pub fn get_token_bytecode() -> &'static [u8] {
-    &[]
+pub fn get_token_bytecode() -> Vec<u8> {
+    State::get().borrow().token_wasm.clone().unwrap_or_default()
 }
 
 impl State {

--- a/src/factory/src/state.rs
+++ b/src/factory/src/state.rs
@@ -68,9 +68,7 @@ impl State {
     }
 
     pub fn set_global_to_self(self) {
-        let state = State::get();
-        let mut state = state.borrow_mut();
-        *state = self;
+        State::get().replace(self);
     }
 }
 

--- a/src/factory/src/state.rs
+++ b/src/factory/src/state.rs
@@ -53,34 +53,14 @@ impl Default for State {
 }
 
 pub fn get_token_bytecode() -> Vec<u8> {
-    State::get().borrow().token_wasm.clone().unwrap_or_default()
+    State::get()
+        .borrow()
+        .token_wasm
+        .clone()
+        .expect("the token bytecode should be set before accessing it")
 }
 
-impl State {
-    pub fn stable_save(&self) {
-        ::ic_cdk::storage::stable_save((self,)).unwrap();
-    }
-
-    pub fn stable_restore() {
-        let (mut loaded,): (Self,) = ::ic_cdk::storage::stable_restore().unwrap();
-        let _ = loaded.token_wasm.take();
-        loaded.set_global_to_self();
-    }
-
-    pub fn set_global_to_self(self) {
-        State::get().replace(self);
-    }
-}
-
-#[::ic_cdk_macros::pre_upgrade]
-fn pre_upgrade() {
-    State::get().borrow().stable_save();
-}
-
-#[::ic_cdk_macros::post_upgrade]
-fn post_upgrade() {
-    State::stable_restore();
-}
+ic_helpers::impl_factory_state_management!(State, &get_token_bytecode());
 
 impl FactoryState<String> for State {
     fn factory(&self) -> &Factory<String> {

--- a/src/factory/tests/set_token_bytecode.rs
+++ b/src/factory/tests/set_token_bytecode.rs
@@ -1,0 +1,11 @@
+use factory::State;
+use ic_storage::IcStorage;
+
+#[tokio::test]
+async fn test_set_token_bytecode_impl() {
+    assert_eq!(State::get().borrow().token_wasm, None);
+
+    factory::api::set_token_bytecode_impl(vec![12, 3]).await;
+
+    assert_eq!(State::get().borrow().token_wasm, Some(vec![12, 3]));
+}


### PR DESCRIPTION
* `set_token_bytecode` will only respond to callers that are known as the controller
* all calls will be rejected by the `inspect_message` method until `set_token_bytecode` is called.

~~This PR doesn't introduce the feature entirely because there is code in `ic-helpers` that forces the bytecode to be a `&'static [u8]` when upgrading canisters, expect another PR there.~~