### PR TITLE
Add no_api feature for inspect message

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,5 @@
 set -e
-cargo build -j`nproc || echo 1` --target wasm32-unknown-unknown --package token --release --features export_api
+cargo build -j`nproc || echo 1` --target wasm32-unknown-unknown --package token --release
 ic-cdk-optimizer target/wasm32-unknown-unknown/release/token.wasm -o src/factory/src/token.wasm
 cargo build -j`nproc || echo 1` --target wasm32-unknown-unknown --package factory --release
 ic-cdk-optimizer target/wasm32-unknown-unknown/release/factory.wasm -o target/wasm32-unknown-unknown/release/factory-opt.wasm

--- a/src/token/Cargo.toml
+++ b/src/token/Cargo.toml
@@ -4,16 +4,15 @@ name = "token"
 version = "0.1.0"
 
 [features]
-default = ["api"]
-api = ["ic-cdk-macros"]
-export_api = []
+default = []
+no_api = []
 
 [dependencies]
 assert-panic = "1.0"
 candid = "0.7"
 common = {path = "../common"}
 ic-cdk = "0.3"
-ic-cdk-macros = {version = "0.3", optional = true}
+ic-cdk-macros = "0.3"
 ic-kit = "0.4.3"
 num-traits = "0.2"
 serde = "1.0"

--- a/src/token/src/canister/inspect.rs
+++ b/src/token/src/canister/inspect.rs
@@ -51,6 +51,7 @@ static TRANSACTION_METHODS: &[&str] = &[
 /// calls for anyone, but update calls have different checks to see, if it's reasonable to spend
 /// canister cycles on accepting this call. Check the comments in this method for details on
 /// the checks for different methods.
+#[cfg(not(feature = "no_api"))]
 #[inspect_message]
 fn inspect_message() {
     let method = ic_cdk::api::call::method_name();


### PR DESCRIPTION
Inspect message also should not be exported from the canister when we use the canister as a dependency. `no_api` feature is used by `ic-canister` to exclude apis in this case, so we add the feature, and add the flag on the `inpect_message` method.