### PR TITLE
[CPROD-833] be method to delete canisters in factory

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: Build-Test
+name: Validate and Bump
 
 on:
   push:
@@ -7,11 +7,28 @@ on:
     branches: [main]
 
 jobs:
-  call-workflow:
-    uses: infinity-swap/ci-wf/.github/workflows/tests-in-dfx.yml@main
+  build-test:
+    uses: infinity-swap/ci-wf/.github/workflows/build-n-test.yml@main
     with:
-      entrypoint-script: ./scripts/build.sh && ./scripts/test.sh
-      ic-module-name: is20
+      skip-test: ${{ github.ref_type == 'tag' }}
+      test-script: |
+        ./scripts/build.sh
+        ./scripts/test.sh
+
     secrets:
       gh_token: ${{ secrets.GH_PKG_TOKEN }}
       gh_login: ${{ secrets.GH_PKG_LOGIN }}
+
+  version-bump:
+    if: ${{ github.ref_type == 'branch' && github.ref == 'refs/heads/main' }}
+    needs: [build-test]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_PKG_TOKEN }}
+        WITH_V: true

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -131,15 +131,14 @@ impl TokenFactoryCanister {
         let state_ref = &mut *self.state.borrow_mut();
         state_ref.check_controller_access()?;
 
-        let token = self.get_token(name.clone()).await;
-
-        if token.is_none() {
-            return Err(TokenFactoryError::FactoryError(FactoryError::NotFound));
-        }
+        let token = match self.get_token(name.clone()).await {
+            Some(token) => token,
+            None => return Err(TokenFactoryError::FactoryError(FactoryError::NotFound)),
+        };
 
         state_ref
             .factory()
-            .drop(token.expect("token exists, checked above"))
+            .drop(token)
             .await?;
         state_ref.factory_mut().forget(&name)?;
 

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -136,7 +136,6 @@ impl TokenFactoryCanister {
             .await
             .ok_or(TokenFactoryError::FactoryError(FactoryError::NotFound))?;
 
-
         state_ref.factory().drop(token).await?;
         state_ref.factory_mut().forget(&name)?;
 

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -128,7 +128,7 @@ impl TokenFactoryCanister {
     #[update]
     async fn delete_token(&self, name: String) -> Result<(), TokenFactoryError> {
         //    Check controller access
-        let state_ref = &mut *self.state.borrow_mut();
+        let mut state_ref = self.state.borrow_mut();
         state_ref.check_controller_access()?;
 
         let token = match self.get_token(name.clone()).await {

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -1,5 +1,5 @@
 //! Module     : factory
-//! Copyright  : 2021 InfinitySwap Team
+//! Copyright  : 2022 InfinitySwap Team
 //! Stability  : Experimental
 
 use std::cell::RefCell;
@@ -120,6 +120,20 @@ impl TokenFactoryCanister {
         state_ref.factory.register(key, canister);
 
         Ok(principal)
+    }
+
+    /// Delete a token.
+    /// The token must be owned by the caller.
+    /// The token will be deleted from the factory and the canister will be destroyed.
+    #[update]
+    async fn delete_token(&self, canister: Principal) -> Result<(), TokenFactoryError> {
+        //    Check controller access
+        let state_ref = &mut *self.state.borrow_mut();
+        state_ref.check_controller_access()?;
+
+        state_ref.factory().drop(canister).await?;
+
+        Ok(())
     }
 }
 

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -136,10 +136,7 @@ impl TokenFactoryCanister {
             None => return Err(TokenFactoryError::FactoryError(FactoryError::NotFound)),
         };
 
-        state_ref
-            .factory()
-            .drop(token)
-            .await?;
+        state_ref.factory().drop(token).await?;
         state_ref.factory_mut().forget(&name)?;
 
         Ok(())

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -126,15 +126,16 @@ impl TokenFactoryCanister {
     /// The token must be owned by the caller.
     /// The token will be deleted from the factory and the removed from the canister registry.
     #[update]
-    async fn delete_token(&self, name: String) -> Result<(), TokenFactoryError> {
+    async fn forget_token(&self, name: String) -> Result<(), TokenFactoryError> {
         //    Check controller access
         let mut state_ref = self.state.borrow_mut();
         state_ref.check_controller_access()?;
 
-        let token = match self.get_token(name.clone()).await {
-            Some(token) => token,
-            None => return Err(TokenFactoryError::FactoryError(FactoryError::NotFound)),
-        };
+        let token = self
+            .get_token(name.clone())
+            .await
+            .ok_or(TokenFactoryError::FactoryError(FactoryError::NotFound))?;
+
 
         state_ref.factory().drop(token).await?;
         state_ref.factory_mut().forget(&name)?;


### PR DESCRIPTION
I have taken inspiration from the `forget_pair` method to implement the delete canister method in the IS20 factory.
Review requested for the method check