### PR TITLE
[CPROD-879] Paginated transactions for IS20

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,9 @@ repos:
             language: script
             files: \.x$
             always_run: true
+        -   id: run-cargo-test
+            name: Run Cargo test
+            entry: /bin/bash -c "cargo test"
+            language: script
+            files: \.x$
+            always_run: true

--- a/spec/IS20.md
+++ b/spec/IS20.md
@@ -191,12 +191,15 @@ query func getTransaction(index: Nat) : TxRecord
 
 #### getTransactions
 
-Returns an array of transaction records in the range `[start, start + limit)`. To fend off DoS attacks, this function is
-allowed to trap, if limit is greater than the limit allowed by the token. This function is also allowed to trap
-if `start + limit > historySize()`
+Returns a list of transactions in paginated form. The `who` is optional, if given, only transactions of the `who` are
+returned. `count` is the number of transactions to return, `transaction_id` is the transaction index which is used as
+the offset of the first transaction to return, any
+
+It returns `PaginatedResult` a struct, which contains `result` which is a list of transactions `Vec<TxRecord>` that meet the requirements of the query,
+and `next_id` which is the index of the next transaction to return.
 
 ```
-query getTransactions(start: nat, limit: nat) : [TxRecord]
+query getTransactions(who: opt principal,count: u32, transaction_id: opt u128) : PaginatedResult
 ```
 
 #### name

--- a/src/token/src/canister.rs
+++ b/src/token/src/canister.rs
@@ -161,10 +161,17 @@ impl TokenCanister {
         })
     }
 
+    /// Returns a list of transactions in paginated form. The `who` is optional, if given, only transactions of the `who` are
+    /// returned. `count` is the number of transactions to return, `transaction_id` is the transaction index which is used as
+    /// the offset of the first transaction to return, any
+    ///
+    /// It returns `PaginatedResult` a struct, which contains `result` which is a list of transactions `Vec<TxRecord>` that meet the requirements of the query,
+    /// and `next_id` which is the index of the next transaction to return.
+
     #[query]
     fn getTransactions(
         &self,
-        caller: Option<Principal>,
+        who: Option<Principal>,
         count: u32,
         transaction_id: Option<u128>,
     ) -> PaginatedResult {
@@ -175,7 +182,7 @@ impl TokenCanister {
         self.state
             .borrow()
             .ledger
-            .get_transactions(caller, count, transaction_id)
+            .get_transactions(who, count, transaction_id)
     }
 
     // This function can only be called as the owner

--- a/src/token/src/canister/erc20_transactions.rs
+++ b/src/token/src/canister/erc20_transactions.rs
@@ -722,24 +722,40 @@ mod tests {
     fn get_transactions_test() {
         let canister = test_canister();
         const COUNT: usize = 5;
-        for _ in 0..COUNT {
+        for i in 1..COUNT {
             canister.transfer(bob(), Nat::from(10), None).unwrap();
         }
 
-        let txs = canister.getTransactions(Nat::from(0), Nat::from(2));
-        assert_eq!(txs.len(), 2);
-        assert_eq!(txs[1].index, Nat::from(1));
+        canister.transfer(bob(), Nat::from(10), None).unwrap();
+        canister.transfer(xtc(), Nat::from(10), None).unwrap();
+        canister.transfer(john(), Nat::from(10), None).unwrap();
 
-        let txs = canister.getTransactions(Nat::from(COUNT), Nat::from(2));
-        assert_eq!(txs.len(), 1);
-        assert_eq!(txs[0].index, Nat::from(COUNT));
+        assert_eq!(canister.getTransactions(None, 10, None).result.len(), 8);
+        assert_eq!(canister.getTransactions(None, 10, Some(3)).result.len(), 4);
+        println!("{:?}", canister.getTransactions(None, 5, None));
+        assert_eq!(
+            canister.getTransactions(Some(bob()), 5, None).result.len(),
+            5
+        );
+        assert_eq!(
+            canister.getTransactions(Some(xtc()), 5, None).result.len(),
+            1
+        );
+        assert_eq!(
+            canister
+                .getTransactions(Some(alice()), 10, Some(5))
+                .result
+                .len(),
+            6
+        );
+        assert_eq!(canister.getTransactions(None, 5, None).next, Some(2));
     }
 
     #[test]
     #[should_panic]
     fn get_transactions_over_limit() {
         let canister = test_canister();
-        canister.getTransactions(Nat::from(0), Nat::from(MAX_TRANSACTION_QUERY_LEN + 1));
+        canister.getTransactions(None, (MAX_TRANSACTION_QUERY_LEN + 1) as u32, None);
     }
 
     #[test]
@@ -747,36 +763,6 @@ mod tests {
     fn get_transaction_not_existing() {
         let canister = test_canister();
         canister.getTransaction(Nat::from(2));
-    }
-
-    #[test]
-    fn get_user_transactions() {
-        let canister = test_canister();
-        canister.transfer(john(), Nat::from(10), None).unwrap();
-        canister.transfer(xtc(), Nat::from(10), None).unwrap();
-        canister.transfer(bob(), Nat::from(10), None).unwrap();
-        canister.transfer(xtc(), Nat::from(10), None).unwrap();
-        canister.transfer(john(), Nat::from(10), None).unwrap();
-
-        let txs = canister.getUserTransactions(alice(), Nat::from(0), Nat::from(6));
-        assert_eq!(txs.len(), 6); // the first transaction is a "mint" transaction to the canister
-        assert_eq!(txs[0].to, john());
-        assert_eq!(txs[1].to, xtc());
-        assert_eq!(txs[2].to, bob());
-        assert_eq!(txs[3].to, xtc());
-        assert_eq!(txs[4].to, john());
-        assert_eq!(txs[5].to, alice()); // this is a mint transaction
-    }
-
-    #[test]
-    fn get_user_transactions_over_limit() {
-        let canister = test_canister();
-
-        for _ in 1..5 {
-            canister.transfer(bob(), Nat::from(10), None).unwrap();
-        }
-        let txs = canister.getUserTransactions(alice(), Nat::from(6), Nat::from(5));
-        assert_eq!(txs.is_empty(), true)
     }
 
     #[test]

--- a/src/token/src/canister/erc20_transactions.rs
+++ b/src/token/src/canister/erc20_transactions.rs
@@ -721,8 +721,8 @@ mod tests {
     #[test]
     fn get_transactions_test() {
         let canister = test_canister();
-        const COUNT: usize = 5;
-        for i in 1..COUNT {
+
+        for _ in 1..5 {
             canister.transfer(bob(), Nat::from(10), None).unwrap();
         }
 
@@ -732,7 +732,7 @@ mod tests {
 
         assert_eq!(canister.getTransactions(None, 10, None).result.len(), 8);
         assert_eq!(canister.getTransactions(None, 10, Some(3)).result.len(), 4);
-        println!("{:?}", canister.getTransactions(None, 5, None));
+
         assert_eq!(
             canister.getTransactions(Some(bob()), 5, None).result.len(),
             5
@@ -749,6 +749,11 @@ mod tests {
             6
         );
         assert_eq!(canister.getTransactions(None, 5, None).next, Some(2));
+        assert_eq!(
+            canister.getTransactions(Some(alice()), 3, Some(5)).next,
+            Some(2)
+        );
+        assert_eq!(canister.getTransactions(Some(bob()), 3, Some(2)).next, None);
     }
 
     #[test]

--- a/src/token/src/ledger.rs
+++ b/src/token/src/ledger.rs
@@ -27,7 +27,7 @@ impl Ledger {
 
     pub fn get_transactions(
         &self,
-        caller: Option<Principal>,
+        who: Option<Principal>,
         count: u32,
         transaction_id: Option<u128>,
     ) -> PaginatedResult {
@@ -36,9 +36,7 @@ impl Ledger {
             .history
             .iter()
             .rev()
-            .filter(|tx| {
-                caller.map_or(true, |c| c == tx.from || c == tx.to || Some(c) == tx.caller)
-            })
+            .filter(|tx| who.map_or(true, |c| c == tx.from || c == tx.to || Some(c) == tx.caller))
             .filter(|tx| transaction_id.map_or(true, |id| id >= tx.index))
             .take(count + 1)
             .cloned()

--- a/src/token/src/ledger.rs
+++ b/src/token/src/ledger.rs
@@ -25,27 +25,6 @@ impl Ledger {
         self.history.get(self.get_index(id)?).cloned()
     }
 
-    // pub fn get_range(&self, start: &Nat, limit: &Nat) -> Vec<TxRecord> {
-    //     let start = match self.get_index(start) {
-    //         Some(v) => v,
-    //         None => {
-    //             if *start > self.vec_offset.clone() {
-    //                 usize::MAX
-    //             } else {
-    //                 0
-    //             }
-    //         }
-    //     };
-
-    //     let limit = limit.0.to_usize().unwrap_or(usize::MAX);
-    //     self.history
-    //         .iter()
-    //         .skip(start)
-    //         .take(limit)
-    //         .cloned()
-    //         .collect()
-    // }
-
     pub fn get_transactions(
         &self,
         caller: Option<Principal>,

--- a/src/token/src/types.rs
+++ b/src/token/src/types.rs
@@ -132,3 +132,9 @@ pub struct AuctionInfo {
     pub first_transaction_id: Nat,
     pub last_transaction_id: Nat,
 }
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct PaginatedResult {
+    pub result: Vec<TxRecord>,
+    pub next: Option<u128>,
+}

--- a/src/token/src/types.rs
+++ b/src/token/src/types.rs
@@ -133,8 +133,12 @@ pub struct AuctionInfo {
     pub last_transaction_id: Nat,
 }
 
+/// `PaginatedResult` is returned by paginated queries i.e `getTransactions`.
 #[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct PaginatedResult {
+    /// The result is the transactions which is the `count` transactions starting from `next` if it exists.
     pub result: Vec<TxRecord>,
+
+    /// This is  the next `id` of the transaction. The `next` is used as offset for the next query if it exits.
     pub next: Option<u128>,
 }


### PR DESCRIPTION
Merged `getUserTransaction` without `getTransactions` to reduce the code duplication when paginating the `transactions`.

@hagsteel I tried to use the same logic as our AMM transactions 