### PR TITLE
fix a bug with transfer_from: this is now preventing sender to be the…

### DIFF
--- a/src/token/src/canister.rs
+++ b/src/token/src/canister.rs
@@ -5,7 +5,6 @@ use candid::Nat;
 use common::types::Metadata;
 use ic_canister::{init, query, update, Canister};
 use ic_cdk::export::candid::Principal;
-use num_traits::ToPrimitive;
 
 use crate::canister::erc20_transactions::{
     approve, burn_as_owner, burn_own_tokens, mint_as_owner, mint_test_token, transfer,
@@ -255,8 +254,8 @@ impl TokenCanister {
 
     #[update]
     fn transferFrom(&self, from: Principal, to: Principal, value: Nat) -> TxReceipt {
-        let caller = CheckedPrincipal::with_recipient(to)?;
-        transfer_from(self, caller, from, value)
+        let caller = CheckedPrincipal::from_to(from, to)?;
+        transfer_from(self, caller, value)
     }
 
     /// Transfers `value` amount to the `to` principal, applying American style fee. This means, that

--- a/src/token/src/canister/erc20_transactions.rs
+++ b/src/token/src/canister/erc20_transactions.rs
@@ -4,7 +4,7 @@ use candid::Nat;
 use ic_cdk::export::Principal;
 
 use crate::canister::is20_auction::auction_principal;
-use crate::principal::{CheckedPrincipal, Owner, TestNet, WithRecipient, SenderRecipient};
+use crate::principal::{CheckedPrincipal, Owner, SenderRecipient, TestNet, WithRecipient};
 use crate::state::{Balances, CanisterState};
 use crate::types::{TxError, TxReceipt};
 

--- a/src/token/src/principal.rs
+++ b/src/token/src/principal.rs
@@ -16,6 +16,12 @@ pub struct WithRecipient {
     recipient: Principal,
 }
 
+/// The `from` principal is not the `to`.
+pub struct SenderRecipient {
+    from: Principal,
+    to: Principal,
+}
+
 pub struct CheckedPrincipal<T>(Principal, T);
 
 impl<T> CheckedPrincipal<T> {
@@ -58,5 +64,24 @@ impl CheckedPrincipal<WithRecipient> {
 
     pub fn recipient(&self) -> Principal {
         self.1.recipient
+    }
+}
+
+impl CheckedPrincipal<SenderRecipient> {
+    pub fn from_to(from: Principal, to: Principal) -> Result<Self, TxError> {
+        let caller = ic::caller();
+        if from == to {
+            Err(TxError::SelfTransfer)
+        } else {
+            Ok(Self(caller, SenderRecipient { from, to }))
+        }
+    }
+
+    pub fn to(&self) -> Principal {
+        self.1.to
+    }
+
+    pub fn from(&self) -> Principal {
+        self.1.from
     }
 }


### PR DESCRIPTION
Fix a bug in the `transfer_from` function. It's no longer possible to have the recipient and the sender be the same principal