### PR TITLE
Remove compile-time env!() call 

### DIFF
--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -32,8 +32,8 @@ pub struct TokenFactoryCanister {
 #[allow(dead_code)]
 impl TokenFactoryCanister {
     #[query]
-    fn git_tag(&self) -> &'static str {
-        env!("GIT_TAG")
+    fn git_tag(&self) -> Option<String> {
+        std::env::var("GIT_TAG").ok()
     }
 
     #[pre_upgrade]

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -32,8 +32,8 @@ pub struct TokenFactoryCanister {
 #[allow(dead_code)]
 impl TokenFactoryCanister {
     #[query]
-    fn git_tag(&self) -> Option<String> {
-        std::env::var("GIT_TAG").ok()
+    fn git_tag(&self) -> &'static str {
+        option_env!("GIT_TAG").unwrap_or("NOT_FOUND")
     }
 
     #[pre_upgrade]


### PR DESCRIPTION
so that it won't throw error when used factory as a dependency since we don't need this in other crates