### PR TITLE
Fix `set_token_bytecode` call

### DIFF
--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -85,7 +85,6 @@ impl TokenFactoryCanister {
 
     #[update]
     pub async fn set_token_bytecode(&self, bytecode: Vec<u8>) -> Result<u32, FactoryError> {
-        println!("caller: {}", ic_canister::ic_kit::ic::caller());
         let state_header = candid_header::<token::state::CanisterState>();
         self.set_canister_code::<token::state::CanisterState>(bytecode, state_header)
     }

--- a/src/factory/src/api.rs
+++ b/src/factory/src/api.rs
@@ -84,11 +84,9 @@ impl TokenFactoryCanister {
     }
 
     #[update]
-    pub async fn set_token_bytecode(
-        &self,
-        bytecode: Vec<u8>,
-        state_header: CandidHeader,
-    ) -> Result<u32, FactoryError> {
+    pub async fn set_token_bytecode(&self, bytecode: Vec<u8>) -> Result<u32, FactoryError> {
+        println!("caller: {}", ic_canister::ic_kit::ic::caller());
+        let state_header = candid_header::<token::state::CanisterState>();
         self.set_canister_code::<token::state::CanisterState>(bytecode, state_header)
     }
 

--- a/src/factory/src/api/inspect_message.rs
+++ b/src/factory/src/api/inspect_message.rs
@@ -13,6 +13,12 @@ fn inspect_message() {
         && factory.controller() == ic_canister::ic_kit::ic::caller()
     {
         return ic_cdk::api::call::accept_message();
+    } else {
+        ic_cdk::api::call::reject(&format!(
+            "the caller {} is not a factory controller {}",
+            ic_canister::ic_kit::ic::caller(),
+            factory.controller()
+        ));
     }
 
     match state.token_wasm {


### PR DESCRIPTION
We have CI failing in amm during the `set_token_bytecode` call, this PR fixes it