### PR TITLE
Add IcStorage instance to StableState

### DIFF
--- a/src/token/api/src/state.rs
+++ b/src/token/api/src/state.rs
@@ -188,7 +188,7 @@ impl Balances {
 /// A wrapper over stable state that is used only during upgrade process.
 /// Since we have two different stable states (canister and auction), we need
 /// to wrap it in this struct during canister upgrade.
-#[derive(CandidType, Deserialize, Default)]
+#[derive(CandidType, Deserialize, Default, IcStorage)]
 pub struct StableState {
     pub token_state: CanisterState,
     pub auction_state: AuctionState,


### PR DESCRIPTION
If we have a wrapper over the is20 token and we want to update from the token to this wrapper, we need to preserve is20 state during serialisation. But since we now write `StableState` to the stable storage, we need to preserve it as a storage field in our own wrapper. For example you can refer to the [governance canister](https://github.com/infinity-swap/governance-canister/pull/5/files#diff-8ed3bc95709bc87a452b6b3fcd32e415b3370ec6bcd40570142c245a6b776dddR36).