### PR TITLE
CPROD-1220 icrc1_transfer must fail if the caller (minting) or receiv…

### DIFF
--- a/src/token/api/src/canister/icrc1_transfer.rs
+++ b/src/token/api/src/canister/icrc1_transfer.rs
@@ -127,7 +127,7 @@ mod tests {
         };
 
         assert!(
-            !canister.icrc1_transfer(transfer).is_ok(),
+            canister.icrc1_transfer(transfer).is_err(),
             "minting with non zero fee must fail!"
         );
     }
@@ -149,7 +149,7 @@ mod tests {
         };
 
         assert!(
-            !canister.icrc1_transfer(transfer).is_ok(),
+            canister.icrc1_transfer(transfer).is_err(),
             "burning with non zero fee must fail!"
         );
     }

--- a/src/token/api/src/canister/icrc1_transfer.rs
+++ b/src/token/api/src/canister/icrc1_transfer.rs
@@ -1,4 +1,5 @@
 use crate::account::{AccountInternal, CheckedAccount, WithRecipient};
+use crate::error::TxError;
 use crate::types::{TransferArgs, TxReceipt};
 
 use super::is20_transactions::burn;
@@ -17,11 +18,26 @@ pub fn icrc1_transfer(
 ) -> TxReceipt {
     let amount = transfer.amount;
     let minter = AccountInternal::new(state.stats.owner, None);
+    // Checks and returns error if the fee is not zero
+    let check_zero_fee = || {
+        if let Some(t) = transfer.fee {
+            if !t.is_zero() {
+                return Err(TxError::BadFee {
+                    expected_fee: 0.into(),
+                });
+            }
+        }
+        Ok(())
+    };
     if caller.inner() == minter {
+        // Minting transfers must have zero fees.
+        check_zero_fee()?;
         return mint(state, caller.inner().owner, transfer.to.into(), amount);
     }
 
     if caller.recipient() == minter {
+        // Burning transfers must have zero fees.
+        check_zero_fee()?;
         return burn(state, caller.recipient().owner, caller.inner(), amount);
     }
 
@@ -92,6 +108,50 @@ mod tests {
     fn test_canister() -> TokenCanisterMock {
         let (_, canister) = test_context();
         canister
+    }
+
+    #[test]
+    fn minting_with_nonzero_fee() {
+        let (_ctx, canister) = test_context();
+
+        let minter = AccountInternal::new(canister.state.borrow_mut().stats.owner, None);
+        let to = Account::from(bob());
+
+        let transfer = TransferArgs {
+            from_subaccount: Some(minter.subaccount),
+            to,
+            amount: Tokens128::from(100),
+            fee: Some(1.into()),
+            memo: None,
+            created_at_time: None,
+        };
+
+        assert!(
+            !canister.icrc1_transfer(transfer).is_ok(),
+            "minting with non zero fee must fail!"
+        );
+    }
+
+    #[test]
+    fn burning_with_nonzero_fee() {
+        let (_ctx, canister) = test_context();
+
+        let to = Account::from(canister.state.borrow_mut().stats.owner);
+        let from_subaccount = Account::from(bob()).subaccount;
+
+        let transfer = TransferArgs {
+            from_subaccount,
+            to,
+            amount: Tokens128::from(100),
+            fee: Some(1.into()),
+            memo: None,
+            created_at_time: None,
+        };
+
+        assert!(
+            !canister.icrc1_transfer(transfer).is_ok(),
+            "burning with non zero fee must fail!"
+        );
     }
 
     #[test]


### PR DESCRIPTION
icrc1_transfer must fail if the caller (minting) or receiver (burning) is minter and the fee value is given other than 0