### PR TITLE
Change the transactions returned in `get_transactions`

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 set -e
 cargo build --target wasm32-unknown-unknown --package is20-token-canister --features export-api --release
-ic-cdk-optimizer target/wasm32-unknown-unknown/release/is20-token-canister.wasm -o src/factory/src/token.wasm
+ic-cdk-optimizer target/wasm32-unknown-unknown/release/is20-token-canister.wasm -o target/wasm32-unknown-unknown/release/token.wasm
 cargo build --target wasm32-unknown-unknown --package token-factory --features export-api --release
 ic-cdk-optimizer target/wasm32-unknown-unknown/release/token-factory.wasm -o target/wasm32-unknown-unknown/release/factory.wasm
 cargo run -p token-factory --features export-api > src/candid/token-factory.did

--- a/src/token/api/src/canister.rs
+++ b/src/token/api/src/canister.rs
@@ -50,7 +50,8 @@ pub mod icrc1_transfer;
 pub mod is20_auction;
 pub mod is20_transactions;
 
-pub(crate) const MAX_TRANSACTION_QUERY_LEN: usize = 1000;
+pub(crate) const MAX_TRANSACTION_REQUEST: usize = 2000;
+pub(crate) const MAX_ACCOUNT_TRANSACTION_REQUEST: usize = 1000;
 // 1 day in seconds.
 pub const DEFAULT_AUCTION_PERIOD_SECONDS: Timestamp = 60 * 60 * 24;
 
@@ -248,11 +249,14 @@ pub trait TokenCanisterAPI: Canister + Sized + AuctionCanister {
         count: usize,
         transaction_id: Option<TxId>,
     ) -> PaginatedResult {
-        self.state().borrow().ledger.get_transactions(
-            who,
-            count.min(MAX_TRANSACTION_QUERY_LEN),
-            transaction_id,
-        )
+        let count = who
+            .map_or(MAX_TRANSACTION_REQUEST, |_| MAX_ACCOUNT_TRANSACTION_REQUEST)
+            .min(count);
+
+        self.state()
+            .borrow()
+            .ledger
+            .get_transactions(who, count, transaction_id)
     }
 
     /// Returns the total number of transactions related to the user `who`.


### PR DESCRIPTION
This PR changes the amount of transactions returned when `get_transactions` returned. This is to be in line on how the ICRC-1 transactions are returned. Now the transactions returned when we call `get_transactions` without `Account` will be 2_000 , and if we pass `Account` we return 1_000.