### PR TITLE
Run test + coverage on git tag in "main"

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,6 @@ jobs:
     uses: infinity-swap/ci-wf/.github/workflows/build-n-test.yml@main
     with:
       container-image: ghcr.io/infinity-swap/ic-dev-full:rust1.64-dfx0.11-rc-2022-09-30
-      skip-test: ${{ github.ref_type == 'tag' }}
       audit-allow-warnings: true
       git-fetch-depth: "0"
       test-script: |


### PR DESCRIPTION
New CI approach would run piplenes only on tags for the main branch