### PR TITLE
Remove lcov.info from release files

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,6 +24,7 @@ jobs:
     uses: infinity-swap/ci-wf/.github/workflows/build-n-test.yml@main
     with:
       container-image: ghcr.io/infinity-swap/ic-dev-full:rust1.64-dfx0.11-rc-2022-09-30
+      enable-target-cache: true
       audit-allow-warnings: true
       git-fetch-depth: "0"
       test-script: |


### PR DESCRIPTION
Looks like lcov.info now will be in the release files but we do not need it there.